### PR TITLE
Upgrade arktype to 2.0.3

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,14 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"type": "npm",
+			"script": "install",
+			"group": "build",
+			"problemMatcher": [],
+			"presentation": {
+				"reveal": "silent"
+			}
+		}
+	]
+}

--- a/nodetest.mjs
+++ b/nodetest.mjs
@@ -1,0 +1,45 @@
+import { type } from "arktype";
+
+const preference = type({
+  key: "string",
+  value: "string|number|boolean",
+});
+
+const userSchemaArktype = type({
+  id: "string",
+  email: "string",
+  profile: {
+    firstName: "string",
+    lastName: "string",
+    age: "number",
+    preferences: preference.array(),
+  },
+  metadata: "Record<string,unknown>",
+  createdAt: "Date",
+  "updatedAt?": "Date",
+});
+
+const validUserData = {
+  id: "123e4567-e89b-12d3-a456-426614174000",
+  email: "test@example.com",
+  profile: {
+    firstName: "John",
+    lastName: "Doe",
+    age: 30,
+    preferences: [
+      { key: "theme", value: "dark" },
+      { key: "notifications", value: true },
+    ],
+  },
+  metadata: {
+    lastLogin: "2024-01-17T00:00:00.000Z",
+  },
+  createdAt: new Date(),
+};
+
+const result = userSchemaArktype(validUserData);
+if (result instanceof type.errors) {
+  console.error("ERROR!", result);
+} else {
+  console.log("Valid user data:", JSON.stringify(result, null, 2));
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,12 @@
       "license": "ISC",
       "dependencies": {
         "@types/node": "^22.10.7",
+<<<<<<< HEAD
         "@vitest/runner": "^3.0.3",
         "arktype": "^2.0.2",
+=======
+        "arktype": "2.0.2",
+>>>>>>> 23ad248 (Fix failing tests and correct schema, upgrade arktype to 2.0.3)
         "typescript": "^5.7.3",
         "vitest": "^3.0.2",
         "zod": "^3.24.1"
@@ -21,7 +25,10 @@
       "version": "0.37.0",
       "resolved": "https://registry.npmjs.org/@ark/schema/-/schema-0.37.0.tgz",
       "integrity": "sha512-uLkP3ixV6LgVEm8wLl0IkAVFfQ0o6IU+uI9AaFQHV4wLMAIwbE90uEDXAEm4H2kv18oypSIUNpz8Q5zzQDDIuw==",
+<<<<<<< HEAD
       "license": "MIT",
+=======
+>>>>>>> 23ad248 (Fix failing tests and correct schema, upgrade arktype to 2.0.3)
       "dependencies": {
         "@ark/util": "0.37.0"
       }
@@ -29,8 +36,12 @@
     "node_modules/@ark/util": {
       "version": "0.37.0",
       "resolved": "https://registry.npmjs.org/@ark/util/-/util-0.37.0.tgz",
+<<<<<<< HEAD
       "integrity": "sha512-4x6wVil/IMnIlHSQczCOXw2Z6YdKPyay942M0FwOHRo5K4vYYcujMNDnBaaW2Xi5A8kJqe8Lnc061SlFX0yGzQ==",
       "license": "MIT"
+=======
+      "integrity": "sha512-4x6wVil/IMnIlHSQczCOXw2Z6YdKPyay942M0FwOHRo5K4vYYcujMNDnBaaW2Xi5A8kJqe8Lnc061SlFX0yGzQ=="
+>>>>>>> 23ad248 (Fix failing tests and correct schema, upgrade arktype to 2.0.3)
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.24.2",
@@ -833,7 +844,10 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/arktype/-/arktype-2.0.2.tgz",
       "integrity": "sha512-bSTdxrlpzRKqHDbBx/Dy8MxqGftfRMUQf0aZbAM1bs8JNguI91zlgdUAfDNSLjKVruj2sdN2Yr/WWgXsdpANEA==",
+<<<<<<< HEAD
       "license": "MIT",
+=======
+>>>>>>> 23ad248 (Fix failing tests and correct schema, upgrade arktype to 2.0.3)
       "dependencies": {
         "@ark/schema": "0.37.0",
         "@ark/util": "0.37.0"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@types/node": "^22.10.7",
     "@vitest/runner": "^3.0.3",
-    "arktype": "^2.0.2",
+    "arktype": "2.0.3",
     "typescript": "^5.7.3",
     "vitest": "^3.0.2",
     "zod": "^3.24.1"

--- a/src/schemas/common.ts
+++ b/src/schemas/common.ts
@@ -1,5 +1,5 @@
-import { z } from 'zod';
-import { type } from 'arktype';
+import { z } from "zod";
+import { type } from "arktype";
 
 // Example complex schema - replace with your actual schema
 export const userSchemaZod = z.object({
@@ -9,14 +9,21 @@ export const userSchemaZod = z.object({
     firstName: z.string().min(2),
     lastName: z.string().min(2),
     age: z.number().int().min(0).max(150),
-    preferences: z.array(z.object({
-      key: z.string(),
-      value: z.union([z.string(), z.number(), z.boolean()])
-    }))
+    preferences: z.array(
+      z.object({
+        key: z.string(),
+        value: z.union([z.string(), z.number(), z.boolean()]),
+      }),
+    ),
   }),
   metadata: z.record(z.string(), z.unknown()),
   createdAt: z.date(),
-  updatedAt: z.date().optional()
+  updatedAt: z.date().optional(),
+});
+
+const preference = type({
+  key: "string",
+  value: "string|number|boolean",
 });
 
 export const userSchemaArktype = type({
@@ -26,12 +33,9 @@ export const userSchemaArktype = type({
     firstName: "string",
     lastName: "string",
     age: "number",
-    preferences: [{
-      key: "string",
-      value: "string|number|boolean"
-    }]
+    preferences: preference.array(),
   },
   metadata: "Record<string,unknown>",
   createdAt: "Date",
-  "updatedAt?": "Date"
+  "updatedAt?": "Date",
 });

--- a/src/schemas/schema.bench.ts
+++ b/src/schemas/schema.bench.ts
@@ -27,27 +27,43 @@ const invalidUserData = {
     lastName: "D", // Too short
     age: 200, // Too high
     preferences: [
-      { key: "theme", value: {} } // Invalid value type
-    ]
+      { key: "theme", value: {} }, // Invalid value type
+    ],
   },
   metadata: {},
   createdAt: "not-a-date",
 };
 
-describe('Schema Validation Benchmarks', () => {
-  bench('Zod Validation (Valid)', () => {
-    userSchemaZod["~standard"].validate(validUserData);
-  }, { iterations: 1_000});
+describe("Schema Validation Benchmarks", () => {
+  bench(
+    "Zod Validation (Valid)",
+    () => {
+      userSchemaZod["~standard"].validate(validUserData);
+    },
+    { iterations: 1_000 },
+  );
 
-  bench('Arktype Validation (Valid)', () => {
-    userSchemaArktype["~standard"].validate(validUserData);
-  }, { iterations: 1_000});
+  bench(
+    "Arktype Validation (Valid)",
+    () => {
+      userSchemaArktype["~standard"].validate(validUserData);
+    },
+    { iterations: 1_000 },
+  );
 
-  bench('Zod Validation (Invalid)', () => {
-    userSchemaZod["~standard"].validate(invalidUserData);
-  }, { iterations: 1_000});
+  bench(
+    "Zod Validation (Invalid)",
+    () => {
+      userSchemaZod["~standard"].validate(invalidUserData);
+    },
+    { iterations: 1_000 },
+  );
 
-  bench('Arktype Validation (Invalid)', () => {
-    userSchemaArktype["~standard"].validate(invalidUserData);
-  }, { iterations: 1_000});
+  bench(
+    "Arktype Validation (Invalid)",
+    () => {
+      userSchemaArktype["~standard"].validate(invalidUserData);
+    },
+    { iterations: 1_000 },
+  );
 });

--- a/src/schemas/schema.test.ts
+++ b/src/schemas/schema.test.ts
@@ -1,8 +1,9 @@
-import { describe, it, expect } from 'vitest';
-import { userSchemaZod, userSchemaArktype } from '../schemas/common';
+import { describe, it, expect } from "vitest";
+import { type } from "arktype";
+import { userSchemaZod, userSchemaArktype } from "../schemas/common";
 
-describe('Schema Validation Tests', () => {
-  describe('Valid Data', () => {
+describe("Schema Validation Tests", () => {
+  describe("Valid Data", () => {
     const validData = {
       id: "123e4567-e89b-12d3-a456-426614174000",
       email: "test@example.com",
@@ -11,25 +12,26 @@ describe('Schema Validation Tests', () => {
         lastName: "Doe",
         age: 30,
         preferences: [
-          { key: "theme", value: "dark" }
-        ]
+          { key: "theme", value: "dark" },
+          { key: "notifications", value: true },
+        ],
       },
       metadata: {},
       createdAt: new Date(),
     };
 
-    it('should validate with Zod', async () => {
-      const result = await userSchemaZod["~standard"].validate(validData);
-      expect(result.issues).toBeFalsy();
+    it("should validate with Zod", () => {
+      const result = userSchemaZod.safeParse(validData);
+      expect(result.success).toBe(true);
     });
 
-    it('should validate with Arktype', async () => {
-      const result = await userSchemaArktype["~standard"].validate(validData);
-      expect(result.issues).toBeFalsy();
+    it("should validate with Arktype", () => {
+      const result = userSchemaArktype(validData);
+      expect(result).not.toBeInstanceOf(type.errors);
     });
   });
 
-  describe('Invalid Data', () => {
+  describe("Invalid Data", () => {
     const invalidData = {
       id: "not-a-uuid",
       email: "not-an-email",
@@ -38,21 +40,21 @@ describe('Schema Validation Tests', () => {
         lastName: "D", // Too short
         age: 200, // Too high
         preferences: [
-          { key: "theme", value: {} } // Invalid value type
-        ]
+          { key: "theme", value: {} }, // Invalid value type
+        ],
       },
       metadata: {},
       createdAt: "not-a-date",
     };
 
-    it('should fail validation with Zod', async () => {
-      const result = await userSchemaZod["~standard"].validate(invalidData);
-      expect(result.issues).toBeTruthy();
+    it("should fail validation with Zod", () => {
+      const result = userSchemaZod.safeParse(invalidData);
+      expect(result.success).toBe(false);
     });
 
-    it('should fail validation with Arktype', async () => {
-      const result = await userSchemaArktype["~standard"].validate(invalidData);
-      expect(result.issues).toBeTruthy();
+    it("should fail validation with Arktype", () => {
+      const result = userSchemaArktype(invalidData);
+      expect(result).toBeInstanceOf(type.errors);
     });
   });
 });


### PR DESCRIPTION
Upgrades arktype to v2.0.3 which seems to have fixed the performance bugs we were seeing with arktype 2.0. Running the benchmarks locally I now get arktype running about twice as fast as zod when parsing succeeds. Running it a few times I've seen it go from around 1.91x faster to 2.2x (never change, Javascript).

<img width="915" alt="image" src="https://github.com/user-attachments/assets/ecc7d201-9fa2-45ae-a7da-47dd25b2cd7d" />
